### PR TITLE
Fixed bug in DQuantileTransformer

### DIFF
--- a/bridgescaler/tests/distributed_test.py
+++ b/bridgescaler/tests/distributed_test.py
@@ -149,7 +149,7 @@ def test_dquantile_scaler():
     assert pd_sub_inv_trans.shape[1] == len(sub_cols), "Did not subset properly on inverse."
     assert type(pd_trans) is type(test_data["pandas"][0]), "Pandas DataFrame type not passed through transform"
     assert type(pd_inv_trans) is type(test_data["pandas"][0]), "Pandas DataFrame type not passed through inverse"
-    xr_dss = DQuantileTransformer(distribution="logistic")
+    xr_dss = DQuantileTransformer(distribution="normal")
     xr_trans = xr_dss.fit_transform(test_data["xarray"][0])
     xr_inv_trans = xr_dss.inverse_transform(xr_trans)
     assert np.all(~np.isnan(xr_trans)), "nans in transform"
@@ -160,11 +160,14 @@ def test_dquantile_scaler():
     combined_scaler = np.sum(dsses_2d)
     assert np.nansum(combined_scaler.centroids_[0, :, 1]) == test_data["n_examples"].sum(), \
         "Summing did not work properly."
-    test_data_c_first = test_data["xarray"][0].transpose("batch", "variable", "y", "x")
+    test_data_c_first = test_data["xarray"][0].transpose("batch", "variable", "y", "x").astype("float32")
     xr_dss_first = xr_dss.transform(test_data_c_first, channels_last=False)
     xr_inv_dss_first = xr_dss.inverse_transform(xr_dss_first, channels_last=False)
     assert xr_dss_first.shape == xr_inv_dss_first.shape, "shape does not match"
-
+    xr_dss_f = DQuantileTransformer(distribution="normal", channels_last=False)
+    xr_dss_f.fit(test_data_c_first)
+    scaled_data_quantile_first = xr_dss_f.transform(test_data_c_first)
+    assert scaled_data_quantile_first.shape == test_data_c_first.shape
     return
 
 


### PR DESCRIPTION
I fixed two issues in DQuantileTransformer discovered by @WillyChap. One is that the fit method was not updated to support channels_first data. The second is that pytdigest, which is the underlying package supporting DQuantileTransformer, only accepts float64 data as input to its cdf and inverse cdf functions. To get around this, I added a casting to float64 for the operation if the data are in float32, but then the output is written back to a float32 array if that is the original format of the data. It's not ideal but should work for now. 