### PR TITLE
Pin Pandas and NumPy versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.7
 install_requires =
     scikit-learn>=1.0
     numpy<2.4
-    pandas
+    pandas<3
     crick
     scipy
     xarray


### PR DESCRIPTION
In order to get a working environment with uv and CI passing again, we need to pin these two dependencies.

Newer version of NumPy aren't supported by Numba, but install anyway and then break stuff if we don't have the version pin.

And then Pandas 3 and newer will break Bridescaler at the moment (test suite fails) so we should pin that until it's addressed.