### PR TITLE
Update bridgescaler to support latest numpy and pandas

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -33,7 +33,7 @@ jobs:
         run: | 
           python -m pip install --upgrade uv
           uv pip install torch --system --index-url https://download.pytorch.org/whl/cpu
-          uv pip install . --system 
+          uv pip install ".[develop]" --system 
           uv pip install ruff pytest --system
       - name: Lint with ruff
         run: |

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           cache: 'pip'
       - name: Install dependencies
         run: | 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -32,4 +32,4 @@ sphinx:
 python:
   install:
     - method: "pip"
-      path: "."
+      path: ".[develop]"

--- a/bridgescaler/backend.py
+++ b/bridgescaler/backend.py
@@ -259,6 +259,9 @@ class NumpyEncoder(json.JSONEncoder):
         elif isinstance(obj, (np.void)):
             return None
 
+        elif isinstance(obj, pd.api.extensions.ExtensionArray):
+            return obj.tolist()
+
         return json.JSONEncoder.default(self, obj)
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,10 @@ name: bridgescaler
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.13
   - pip
-  - numpy<2
-  - scipy>=1.11.0
+  - numpy
+  - scipy
   - pandas
   - scikit-learn
   - pyarrow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,6 @@ license = {text = "MIT"}
 keywords = ["machine learning"]
 classifiers = [
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -23,21 +20,26 @@ classifiers = [
 ]
 dependencies = [
     "scikit-learn>=1.0",
-    "numpy<2.4",
-    "pandas<3",
+    "numpy",
+    "pandas",
     "crick",
     "scipy",
     "xarray",
     "numba",
-    "sphinx",
-    "sphinx-book-theme",
-    "sphinx-autoapi",
     "setuptools_scm",
     "setuptools",
-    "myst_parser"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 
+[project.optional-dependencies]
+develop = ["sphinx",
+           "sphinx-book-theme",
+           "sphinx-autoapi",
+           "myst_parser",
+           "ruff",
+           "pre-commit",
+           "pytest"
+]
 [project.urls]
 Homepage = "https://github.com/NCAR/bridgescaler"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,9 @@
-pandas<3
-numpy<2.4
+pandas
+numpy
 scikit-learn>=1.0
 crick
 xarray
 scipy
 numba
-sphinx
-sphinx-book-theme
 setuptools_scm
 setuptools
-sphinx-autoapi
-myst_parser


### PR DESCRIPTION
I have updated bridgescaler to support the latest numpy and pandas versions and fixed the error that was causing tests to fail with newer versions of pandas. This should ensure upstream issues related to CREDIT no longer break.