### PR TITLE
Quantile transform speedup

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,34 @@ dss_combined = np.sum([dss_1, dss_2])
 dss_combined.transform(x_1, channels_last=False)
 ```
 
+#### PyTorch Tensor Scalers
+If PyTorch (>= 2.0) is installed, tensor versions of the distributed scalers are available in
+`bridgescaler.distributed_tensor` (`DStandardScalerTensor`, `DMinMaxScalerTensor`,
+`DQuantileScalerTensor`). They operate directly on `torch.Tensor` inputs and run on CPU or GPU,
+mirroring the numpy API (fit/transform/inverse_transform, summing to combine, and channels-last or
+channels-first layouts). Variable names are carried on a `variable_names` attribute of the tensor so
+subsets and reordering work as with pandas/xarray.
+
+`DQuantileScalerTensor` supports two performance options:
+* `compile=True` wraps the vmapped per-variable kernel in `torch.compile` for a sizable speedup on
+  CPU/CUDA (skipped on MPS).
+* `fast_transform=True` replaces the exact TDigest CDF/quantile evaluation in both `transform` and
+  `inverse_transform` with a per-variable monotone-cubic (PCHIP) approximation fit to the fitted
+  quantile curve. This trades a small, tail-concentrated approximation error (typically well below
+  the TDigest's own error) for roughly a 3x transform speedup. `n_knots` (default 256) controls the
+  number of interpolation knots. The knots are derived from the digest and rebuilt automatically when
+  the scaler is re-fit or combined.
+
+```python
+from bridgescaler.distributed_tensor import DQuantileScalerTensor
+import torch
+
+x = torch.rand(10000, 4)
+scaler = DQuantileScalerTensor(distribution="normal", fast_transform=True)
+x_transformed = scaler.fit_transform(x)
+x_restored = scaler.inverse_transform(x_transformed)
+```
+
 ### Group Scaler
 The group scalers use the same scaling parameters for a group of similar
 variables rather than scaling each column independently. This is useful for situations where variables are related, 

--- a/bridgescaler/backend.py
+++ b/bridgescaler/backend.py
@@ -138,6 +138,12 @@ def read_scaler(scaler_str):
                 value = v # keep as it is
             elif (k == "centroids_mean_tensor") or (k == "centroids_weight_tensor"):
                 value = [torch.tensor(c) for c in v]  # convert to a list with tensors
+            elif isinstance(v, bool) and not isinstance(v, np.generic):
+                value = v  # keep python bool flags (e.g. channels_last, _fit) as-is
+            elif isinstance(v, (int, float)) and not isinstance(v, np.generic):
+                # keep python scalar params (e.g. min_val, max_val, compression) as-is; torch.tensor(float)
+                # would silently downcast to float32 and corrupt precision-sensitive values like max_val.
+                value = v
             elif isinstance(v, np.bool_):
                 value = torch.tensor(bool(v))
             else:

--- a/bridgescaler/backend.py
+++ b/bridgescaler/backend.py
@@ -134,7 +134,9 @@ def read_scaler(scaler_str):
 
         # 2. Handle Tensors & Special Cases
         elif is_tensor:
-            if isinstance(v, str) or (k == "x_columns_") or (k == "centroids_"):
+            if v is None:
+                value = None  # keep unset/lazy attributes (e.g. lazily-built fast_transform knots) as None
+            elif isinstance(v, str) or (k == "x_columns_") or (k == "centroids_"):
                 value = v # keep as it is
             elif (k == "centroids_mean_tensor") or (k == "centroids_weight_tensor"):
                 value = [torch.tensor(c) for c in v]  # convert to a list with tensors

--- a/bridgescaler/distributed_tensor.py
+++ b/bridgescaler/distributed_tensor.py
@@ -645,6 +645,94 @@ def tdigest_quantile_tensor(qv, cent_mean, cent_weight, t_min, t_max, n_real):
     return out
 
 
+def compute_pchip_slopes(x, y):
+    """Vectorized Fritsch-Carlson monotone-cubic slopes (matching scipy's PchipInterpolator).
+
+    Computes the derivative at every knot for a shape-preserving monotone cubic Hermite spline, for
+    each variable (row) of ``x``/``y`` at once. Interior slopes use the weighted-harmonic-mean rule
+    (set to 0 at local extrema so the spline never overshoots); endpoints use scipy's non-centered
+    three-point edge formula with the same monotonicity limiting.
+
+    Args:
+        x (numpy.ndarray): strictly-increasing knot locations, shape ``(n_vars, M)``.
+        y (numpy.ndarray): knot values, shape ``(n_vars, M)``.
+
+    Returns:
+        numpy.ndarray: knot slopes, shape ``(n_vars, M)``.
+    """
+    n, M = x.shape
+    m = np.zeros_like(x)
+    # tied knots (bumped by a tiny epsilon at saturated tails) produce huge/degenerate secants; the results
+    # there are discarded by the monotonicity masks below, so suppress the expected divide/invalid warnings.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        h = np.diff(x, axis=1)
+        delta = np.diff(y, axis=1) / h
+        if M < 3:
+            m[:, 0] = delta[:, 0]
+            m[:, -1] = delta[:, -1]
+            return m
+        hk = h[:, 1:]
+        hk1 = h[:, :-1]
+        dk = delta[:, 1:]
+        dk1 = delta[:, :-1]
+        w1 = 2 * hk + hk1
+        w2 = hk + 2 * hk1
+        m_int = (w1 + w2) / (w1 / dk1 + w2 / dk)
+        mono = (dk1 * dk) > 0  # only assign a nonzero slope where the secants agree in sign
+        m[:, 1:-1] = np.where(mono, m_int, 0.0)
+
+        def edge(h0, h1, d0, d1):
+            me = ((2 * h0 + h1) * d0 - h0 * d1) / (h0 + h1)
+            me = np.where(np.sign(me) != np.sign(d0), 0.0, me)
+            limit = (np.sign(d0) != np.sign(d1)) & (np.abs(me) > 3 * np.abs(d0))
+            return np.where(limit, 3 * d0, me)
+
+        m[:, 0] = edge(h[:, 0], h[:, 1], delta[:, 0], delta[:, 1])
+        m[:, -1] = edge(h[:, -1], h[:, -2], delta[:, -1], delta[:, -2])
+    return m
+
+
+def pchip_eval_tensor(x_knots, z_knots, m_knots, xv):
+    """Per-variable monotone cubic-Hermite (PCHIP) evaluation of the fitted transform (fast path).
+
+    Written branchlessly / fixed-shape so it composes with ``torch.vmap`` over the channel dimension.
+    Locates each element of ``xv`` among the ascending ``x_knots`` (via ``_bucketize`` for MPS
+    friendliness), then evaluates the Hermite cubic using the precomputed knot slopes ``m_knots``.
+    Values outside ``[x_knots[0], x_knots[-1]]`` saturate to the end z-knots, which equal
+    ``dist_ppf(min_val)`` / ``dist_ppf(max_val)`` -- matching the exact path's ``min_val``/``max_val``
+    clamping.
+
+    Args:
+        x_knots (torch.Tensor): ascending knot locations for one variable, shape ``(M,)``.
+        z_knots (torch.Tensor): transformed value at each knot, shape ``(M,)`` (shared across vars).
+        m_knots (torch.Tensor): PCHIP slope at each knot for one variable, shape ``(M,)``.
+        xv (torch.Tensor): values to transform, any shape.
+
+    Returns:
+        torch.Tensor: transformed values with the same shape as ``xv``.
+    """
+    M = x_knots.shape[0]
+    i = torch.clamp(_bucketize(x_knots, xv, "left"), 1, M - 1)
+    x0 = x_knots[i - 1]
+    x1 = x_knots[i]
+    y0 = z_knots[i - 1]
+    y1 = z_knots[i]
+    m0 = m_knots[i - 1]
+    m1 = m_knots[i]
+    h = x1 - x0
+    t = (xv - x0) / torch.where(h == 0, torch.ones_like(h), h)
+    t2 = t * t
+    t3 = t2 * t
+    h00 = 2 * t3 - 3 * t2 + 1
+    h10 = t3 - 2 * t2 + t
+    h01 = -2 * t3 + 3 * t2
+    h11 = t3 - t2
+    z = h00 * y0 + h10 * h * m0 + h01 * y1 + h11 * h * m1
+    z = torch.where(xv <= x_knots[0], z_knots[0], z)
+    z = torch.where(xv >= x_knots[-1], z_knots[-1], z)
+    return z
+
+
 class DQuantileScalerTensor(DBaseScalerTensor):
     """
     Distributed Quantile Scaler for tensors that uses the crick TDigest Cython library to compute quantiles across multiple
@@ -662,14 +750,24 @@ class DQuantileScalerTensor(DBaseScalerTensor):
             vmapped per-variable kernel, which fuses the many elementwise ops for a sizable speedup on CPU/CUDA.
             Compilation is skipped on MPS (its inductor backend is immature and the ``_bucketize`` fallback already
             handles MPS); the default False preserves the plain eager-vmap behavior.
+        fast_transform: If True, ``transform`` and ``inverse_transform`` use a monotone cubic (PCHIP) approximation
+            of the fitted mapping instead of the exact TDigest CDF/quantile evaluation. Knots are placed at
+            ``n_knots`` levels spaced uniformly in the output space; each direction is interpolated with a single
+            searchsorted over ``n_knots`` (far fewer ops than the full kernel) for roughly a 3x speedup, at the cost
+            of a small approximation error that is typically well below the TDigest's own error (see
+            scripts/quantile_lut_experiment.py). Default False.
+        n_knots: Number of PCHIP knots per variable when ``fast_transform`` is enabled (default 256). Ignored
+            otherwise. Must be >= 4.
     """
     def __init__(self, compression=250, distribution="uniform", min_val=0.0000001, max_val=0.9999999,
-                 channels_last=True, compile=False):
+                 channels_last=True, compile=False, fast_transform=False, n_knots=256):
         self.compression = compression
         self.distribution = distribution
         self.min_val = min_val
         self.max_val = max_val
         self.compile = compile
+        self.fast_transform = fast_transform
+        self.n_knots = n_knots
         self.centroids_ = None
         self.size_ = None
         self.min_ = None
@@ -682,6 +780,12 @@ class DQuantileScalerTensor(DBaseScalerTensor):
         self.centroids_mean_stacked = None    # (n_vars, max_centroids), padding means = +inf
         self.centroids_weight_stacked = None  # (n_vars, max_centroids), padding weights = 0
         self.centroids_count = None           # (n_vars,) number of real centroids per variable
+        # PCHIP knots for the optional fast_transform path; derived from the digest, rebuilt lazily,
+        # invalidated on every fit/merge (see tensorize_attributes / ensure_pchip_knots).
+        self.knots_x_ = None                  # (n_vars, n_knots) ascending knot locations
+        self.knots_z_ = None                  # (n_knots,) transformed value at each knot (shared)
+        self.knots_m_ = None                  # (n_vars, n_knots) forward PCHIP slopes dz/dx at the knots
+        self.knots_minv_ = None               # (n_vars, n_knots) inverse PCHIP slopes dx/dz at the knots
 
         super().__init__(channels_last=channels_last)
 
@@ -711,6 +815,11 @@ class DQuantileScalerTensor(DBaseScalerTensor):
         self.min_tensor = torch.from_numpy(self.min_)
         self.max_tensor = torch.from_numpy(self.max_)
         self.build_stacked_centroids()
+        # invalidate any fast_transform knots; they are rebuilt lazily from the updated digest
+        self.knots_x_ = None
+        self.knots_z_ = None
+        self.knots_m_ = None
+        self.knots_minv_ = None
         return
 
     def build_stacked_centroids(self):
@@ -743,6 +852,66 @@ class DQuantileScalerTensor(DBaseScalerTensor):
         """Rebuild the stacked centroid tensors if missing (e.g. loaded from an older serialized scaler)."""
         if self.centroids_mean_stacked is None and self.centroids_mean_tensor is not None:
             self.build_stacked_centroids()
+        return
+
+    def build_pchip_knots(self):
+        """Build per-variable monotone-cubic (PCHIP) knots approximating the exact transform (fast path).
+
+        Knots are spaced uniformly in the *output* ``z`` over ``[dist_ppf(min_val), dist_ppf(max_val)]`` rather than
+        in probability, which bounds the per-bin output error (each bin spans a fixed z-height) regardless of the
+        input distribution -- equal-probability spacing badly under-resolves the steep tails. Each z-knot is mapped
+        to a probability via the distribution CDF, and the x-knot is the digest quantile at that probability (via
+        ``tdigest_quantile_tensor``). Together with the PCHIP slopes these let ``transform`` interpolate ``x -> z``
+        with a single searchsorted over ``n_knots``, instead of the full TDigest CDF evaluation. Cheap and one-time;
+        rebuilt lazily and invalidated on every fit/merge.
+        """
+        assert self.is_fit(), "Scaler has not been fit."
+        assert self.n_knots >= 4, "fast_transform requires n_knots >= 4."
+        self.ensure_stacked_centroids()
+        M = int(self.n_knots)
+        dtype = self.centroids_mean_stacked.dtype
+        # z-knots: uniform in output space between the distribution ppf of min_val and max_val; p = dist_cdf(z)
+        if self.distribution == "normal":
+            z_lo, z_hi = torch.special.ndtri(torch.tensor([self.min_val, self.max_val], dtype=dtype))
+            z_knots = torch.linspace(float(z_lo), float(z_hi), M, dtype=dtype)
+            p = torch.special.ndtr(z_knots)
+        elif self.distribution == "logistic":
+            z_lo, z_hi = torch.logit(torch.tensor([self.min_val, self.max_val], dtype=dtype))
+            z_knots = torch.linspace(float(z_lo), float(z_hi), M, dtype=dtype)
+            p = torch.sigmoid(z_knots)
+        else:  # uniform: transform output is the CDF itself, so z == p
+            z_knots = torch.linspace(self.min_val, self.max_val, M, dtype=dtype)
+            p = z_knots.clone()
+        p = torch.clamp(p, self.min_val, self.max_val)
+        # x-knots: digest quantile of each probability level, computed for every variable at once via vmap
+        qfn = torch.vmap(tdigest_quantile_tensor, in_dims=(None, 0, 0, 0, 0, 0))
+        x_knots = qfn(p,
+                      self.centroids_mean_stacked,
+                      self.centroids_weight_stacked,
+                      self.min_tensor.to(dtype),
+                      self.max_tensor.to(dtype),
+                      self.centroids_count)
+        x_np = x_knots.cpu().numpy()
+        # enforce strictly-increasing x per variable (quantiles can tie at saturated tails), which PCHIP requires
+        x_np = np.maximum.accumulate(x_np, axis=1)
+        ties = np.diff(x_np, axis=1) <= 0
+        if ties.any():
+            x_np[:, 1:][ties] = x_np[:, :-1][ties] + 1e-12
+        z_np = np.broadcast_to(z_knots.cpu().numpy(), x_np.shape).copy()
+        # forward slopes dz/dx (transform) and inverse slopes dx/dz (inverse_transform); z-knots are strictly
+        # increasing so the inverse fit needs no de-duplication, while x-knots were made monotone above.
+        m_np = compute_pchip_slopes(x_np, z_np)
+        minv_np = compute_pchip_slopes(z_np, x_np)
+        self.knots_x_ = torch.from_numpy(np.ascontiguousarray(x_np))
+        self.knots_z_ = z_knots.to(torch.float64)
+        self.knots_m_ = torch.from_numpy(np.ascontiguousarray(m_np))
+        self.knots_minv_ = torch.from_numpy(np.ascontiguousarray(minv_np))
+        return
+
+    def ensure_pchip_knots(self):
+        """Build the fast_transform knots if missing (lazily, and after load / refit / merge)."""
+        if self.knots_x_ is None and self.is_fit():
+            self.build_pchip_knots()
         return
 
     def fit(self, x, weight=None):
@@ -821,8 +990,48 @@ class DQuantileScalerTensor(DBaseScalerTensor):
             cache[key] = batched
         return batched
 
+    def _get_fast_fn(self, kind, channel_dim, device_type):
+        """Build (and cache) the vmapped PCHIP evaluator for the fast_transform path.
+
+        Mirrors ``_get_batched_fn`` but maps ``pchip_eval_tensor`` over the channel dimension. The search/output
+        roles swap between directions: for ``"transform"`` the search knots are the per-variable x-knots and the
+        outputs are the shared z-knots; for ``"inverse"`` the search knots are the shared z-knots and the outputs
+        are the per-variable x-knots. ``in_dims`` places the per-variable arg on dim 0 and the shared arg at
+        ``None`` accordingly. Optionally torch.compiled off MPS.
+        """
+        use_compile = bool(self.compile) and device_type != "mps"
+        # namespaced ("fast_*") so these keys never collide with _get_batched_fn's ("transform"/"inverse")
+        # entries in the shared _BATCHED_CACHE
+        key = ("fast_" + kind, channel_dim, use_compile)
+        cache = _BATCHED_CACHE.get(self)
+        if cache is None:
+            cache = {}
+            _BATCHED_CACHE[self] = cache
+        batched = cache.get(key)
+        if batched is None:
+            # transform: (x_knots per-var, z_knots shared, slopes per-var, data on channel_dim)
+            # inverse:   (z_knots shared, x_knots per-var, slopes per-var, data on channel_dim)
+            in_dims = (0, None, 0, channel_dim) if kind == "transform" else (None, 0, 0, channel_dim)
+            batched = torch.vmap(pchip_eval_tensor, in_dims=in_dims, out_dims=channel_dim)
+            if use_compile:
+                batched = torch.compile(batched, fullgraph=True)
+            cache[key] = batched
+        return batched
+
     def transform(self, x, channels_last=None):
         xv, x_transformed, channels_last, channel_dim, x_col_order = self.process_x_for_transform(x, channels_last)
+        if self.fast_transform:
+            # Approximate path: interpolate the fitted transform with a per-variable monotone cubic (PCHIP),
+            # replacing the exact TDigest CDF evaluation with a single searchsorted over n_knots. Knots follow
+            # the requested channel order (x_col_order) and are moved onto xv's device/dtype.
+            self.ensure_pchip_knots()
+            order = torch.as_tensor(x_col_order, dtype=torch.long)
+            xk = self.knots_x_.index_select(0, order).to(xv.device, dtype=xv.dtype)
+            mk = self.knots_m_.index_select(0, order).to(xv.device, dtype=xv.dtype)
+            zk = self.knots_z_.to(xv.device, dtype=xv.dtype)
+            batched = self._get_fast_fn("transform", channel_dim, xv.device.type)
+            x_transformed = batched(xk, zk, mk, xv)
+            return self.package_transformed_x(x_transformed, x)
         mean, weight, t_min, t_max, n_real = self._gather_scales(x_col_order, xv)
         # vmap parallelizes the per-variable transform over the channel dimension, which is far faster than a
         # Python loop; when compile is enabled the fused torch.compile variant is used (see _get_batched_fn).
@@ -838,6 +1047,18 @@ class DQuantileScalerTensor(DBaseScalerTensor):
 
     def inverse_transform(self, x, channels_last=None):
         xv, x_transformed, channels_last, channel_dim, x_col_order = self.process_x_for_transform(x, channels_last)
+        if self.fast_transform:
+            # Approximate path: interpolate the fitted inverse with a per-variable monotone cubic (PCHIP),
+            # searching the input z-values in the shared z-knots and interpolating to the per-variable x-knots
+            # (roles swapped relative to transform). Uses the precomputed dx/dz slopes (knots_minv_).
+            self.ensure_pchip_knots()
+            order = torch.as_tensor(x_col_order, dtype=torch.long)
+            zk = self.knots_z_.to(xv.device, dtype=xv.dtype)
+            xk = self.knots_x_.index_select(0, order).to(xv.device, dtype=xv.dtype)
+            mk = self.knots_minv_.index_select(0, order).to(xv.device, dtype=xv.dtype)
+            batched = self._get_fast_fn("inverse", channel_dim, xv.device.type)
+            x_transformed = batched(zk, xk, mk, xv)
+            return self.package_transformed_x(x_transformed, x)
         mean, weight, t_min, t_max, n_real = self._gather_scales(x_col_order, xv)
 
         batched = self._get_batched_fn("inverse", channel_dim, xv.device.type)

--- a/bridgescaler/distributed_tensor.py
+++ b/bridgescaler/distributed_tensor.py
@@ -13,8 +13,6 @@ import numpy as np
 from numpy.lib.recfunctions import structured_to_unstructured, unstructured_to_structured
 CENTROID_DTYPE = np.dtype([('mean', np.float64), ('weight', np.float64)])
 
-warnings.simplefilter("always")
-
 # Cache of vmapped (and optionally torch.compiled) transform functions, keyed weakly by scaler instance so
 # nothing non-serializable is stored on the scaler's __dict__ and entries are dropped when the scaler is freed.
 _BATCHED_CACHE = weakref.WeakKeyDictionary()

--- a/bridgescaler/distributed_tensor.py
+++ b/bridgescaler/distributed_tensor.py
@@ -4,6 +4,7 @@ from . import require_torch
 require_torch()   # enforce torch availability/version at import time
 import torch
 
+import weakref
 from copy import deepcopy
 from functools import partial
 
@@ -13,6 +14,34 @@ from numpy.lib.recfunctions import structured_to_unstructured, unstructured_to_s
 CENTROID_DTYPE = np.dtype([('mean', np.float64), ('weight', np.float64)])
 
 warnings.simplefilter("always")
+
+# Cache of vmapped (and optionally torch.compiled) transform functions, keyed weakly by scaler instance so
+# nothing non-serializable is stored on the scaler's __dict__ and entries are dropped when the scaler is freed.
+_BATCHED_CACHE = weakref.WeakKeyDictionary()
+
+
+def _bucketize(sorted_seq, values, side):
+    """Return insertion indices of ``values`` into the ascending 1-D ``sorted_seq`` (like ``torch.searchsorted``).
+
+    ``torch.searchsorted`` has a pathologically slow Metal kernel, so on MPS the indices are computed with a
+    broadcast reduction instead (O(N*K) memory, but roughly an order of magnitude faster there). On CPU/CUDA the
+    binary-search ``torch.searchsorted`` is used, which is far faster and memory-light where it is well
+    implemented. The device check is a static branch, so it does not break the graph under ``torch.compile``.
+
+    Args:
+        sorted_seq (torch.Tensor): ascending boundaries, shape ``(K,)`` (per variable under vmap).
+        values (torch.Tensor): values to locate, any shape.
+        side (str): ``"left"`` (count of boundaries strictly less than each value) or ``"right"`` (count of
+            boundaries less than or equal to each value), matching ``torch.searchsorted`` semantics.
+
+    Returns:
+        torch.Tensor: int64 indices with the same shape as ``values``.
+    """
+    if values.device.type == "mps":
+        if side == "left":
+            return torch.sum(sorted_seq < values.unsqueeze(-1), dim=-1)
+        return torch.sum(sorted_seq <= values.unsqueeze(-1), dim=-1)
+    return torch.searchsorted(sorted_seq, values, side=side)
 
 
 class DBaseScalerTensor:
@@ -455,9 +484,14 @@ def fit_variable_tensor(var_index, xv, compression=None, channels_last=None):
     return td_obj
 
 
-def transform_variable_tensor(cent_mean, cent_weight, t_min, t_max, xv,
+def transform_variable_tensor(cent_mean, cent_weight, t_min, t_max, n_real, xv,
                        min_val=0.000001, max_val=0.9999999, distribution="normal"):
-    x_transformed = tdigest_cdf_tensor(xv, cent_mean, cent_weight, t_min, t_max)
+    """Per-variable forward quantile transform, written branchlessly so it can be wrapped in ``torch.vmap``.
+
+    ``cent_mean``/``cent_weight`` are the padded ``(K,)`` centroid tensors for a single variable (padding means
+    are ``+inf`` and padding weights are ``0``); ``n_real`` is the number of valid (non-padding) centroids.
+    """
+    x_transformed = tdigest_cdf_tensor(xv, cent_mean, cent_weight, t_min, t_max, n_real)
     x_transformed = torch.clamp(x_transformed, min=min_val, max=max_val)
     if distribution == "normal":
         x_transformed = torch.special.ndtri(x_transformed)
@@ -466,144 +500,148 @@ def transform_variable_tensor(cent_mean, cent_weight, t_min, t_max, xv,
     return x_transformed
 
 
-def inv_transform_variable_tensor(cent_mean, cent_weight, t_min, t_max, xv,
+def inv_transform_variable_tensor(cent_mean, cent_weight, t_min, t_max, n_real, xv,
                                   distribution="normal"):
+    """Per-variable inverse quantile transform, branchless for ``torch.vmap``. See ``transform_variable_tensor``."""
     if distribution == "normal":
         x_intermediate = torch.special.ndtr(xv)
     elif distribution == "logistic":
         x_intermediate = torch.sigmoid(xv)
     else:
         x_intermediate = xv
-    x_transformed = tdigest_quantile_tensor(x_intermediate, cent_mean, cent_weight, t_min, t_max)
+    x_transformed = tdigest_quantile_tensor(x_intermediate, cent_mean, cent_weight, t_min, t_max, n_real)
     return x_transformed
 
 
-def tdigest_cdf_tensor(xv, cent_mean, cent_weight, t_min, t_max):
-    num_centroids = cent_mean.numel()
+def tdigest_cdf_tensor(xv, cent_mean, cent_weight, t_min, t_max, n_real):
+    """Evaluate the TDigest CDF at every element of ``xv`` for a single variable.
 
+    This is a branchless, fixed-shape reformulation of the original masked implementation so that it composes
+    with ``torch.vmap`` over the channel dimension. All four interpolation cases are computed everywhere and
+    selected with ``torch.where`` rather than boolean-mask assignment, and centroid arrays are padded to a
+    common length ``K`` (``+inf`` means, ``0`` weights) so that ``n_real`` (not ``K``) delimits the real
+    centroids.
+
+    Args:
+        xv (torch.Tensor): values to evaluate, any shape.
+        cent_mean (torch.Tensor): padded ``(K,)`` centroid means, ascending, padding = ``+inf``.
+        cent_weight (torch.Tensor): padded ``(K,)`` centroid weights, padding = ``0``.
+        t_min, t_max: scalar min/max of the digest.
+        n_real: number of valid centroids (0-d integer tensor works under vmap).
+
+    Returns:
+        torch.Tensor: CDF values in ``[0, 1]`` with the same shape as ``xv``.
+    """
+    K = cent_mean.numel()
     cum_sum = torch.cumsum(cent_weight, dim=0)
     cent_merged_weight = cum_sum - (cent_weight / 2.0)
     total_weight = cent_weight.sum()
+    eps = torch.finfo(xv.dtype).eps
 
-    out = torch.full(xv.shape, torch.nan, dtype=xv.dtype, device=xv.device)
+    # index of the last real centroid, and clamped search indices that never reach the padding region
+    nlast = torch.clamp(n_real - 1, min=0)
+    i_l = _bucketize(cent_mean, xv, "left")   # in [0, K]
+    i_r = _bucketize(cent_mean, xv, "right")  # in [0, K]
+    i_l_c = torch.minimum(i_l, nlast)
+    i_r_c = torch.minimum(i_r, nlast)
 
-    if num_centroids == 0:
-        return out
+    first_mean = cent_mean[0]
+    last_mean = cent_mean[nlast]
+    last_w = cent_weight[nlast]
 
-    # Single centroid
-    if num_centroids == 1:
-        out = torch.where(xv < t_min, 0.0, out)
-        out = torch.where(xv > t_max, 1.0, out)
+    # --- case m1: t_min < x < first centroid ---
+    dw1 = cent_merged_weight[0] / 2.0
+    denom1 = first_mean - t_min
+    res_m1 = dw1 * (xv - t_min) / torch.where(denom1 == 0, 1.0, denom1) / total_weight
 
-        mask = (xv >= t_min) & (xv <= t_max)
-        eps = torch.finfo(xv.dtype).eps # find the Machine Epsilon
-        if t_max - t_min < eps: # smaller than the smallest measurable gap
-            out[mask] = 0.5
-        else:
-            out[mask] = (xv[mask] - t_min) / (t_max - t_min)
-        return out
+    # --- case m2: last centroid < x < t_max ---
+    dw2 = last_w / 2.0
+    denom2 = t_max - last_mean
+    res_m2 = 1.0 - dw2 * (t_max - xv) / torch.where(denom2 == 0, 1.0, denom2) / total_weight
 
-    # Multi-centroid
-    # clamping extremes
-    out = torch.where(xv >= t_max, 1.0, out)
-    out = torch.where(xv <= t_min, 0.0, out)
+    # --- case m3: x equals a centroid mean ---
+    res_m3 = cent_merged_weight[i_r_c] / total_weight
 
-    # identify indices that still need processing
-    active_mask = torch.isnan(out)
-    if not active_mask.any():
-        return out
+    # --- case m4: x strictly between two centroids ---
+    # keep idx_l in [1, K-1] so the (discarded) result never indexes out of bounds when K == 1
+    idx_l = torch.minimum(torch.clamp(i_l, min=1), torch.clamp(nlast, min=1)).clamp(max=max(K - 1, 0))
+    x0 = cent_mean[idx_l - 1]
+    x1 = cent_mean[idx_l]
+    dw4 = 0.5 * (cent_weight[idx_l - 1] + cent_weight[idx_l])
+    denom4 = x1 - x0
+    res_m4 = (cent_merged_weight[idx_l - 1] + dw4 * (xv - x0) / torch.where(denom4 == 0, 1.0, denom4)) / total_weight
 
-    x_active = xv[active_mask]
+    # select case by priority m1 > m2 > m3 > m4
+    m1 = xv < first_mean
+    m2 = (~m1) & (i_l >= n_real)
+    m3 = (~m1) & (~m2) & (cent_mean[i_l_c] == xv)
+    res_multi = torch.where(m1, res_m1,
+                torch.where(m2, res_m2,
+                torch.where(m3, res_m3, res_m4)))
+    # multi-centroid extremes
+    res_multi = torch.where(xv >= t_max, torch.ones_like(res_multi),
+                torch.where(xv <= t_min, torch.zeros_like(res_multi), res_multi))
 
-    # binary Search
-    # i_l is the index where x_active would be inserted to maintain order, "cent_mean" is a sorted tensor
-    i_l = torch.searchsorted(cent_mean, x_active, side="left") # (default): $S[i-1] < v \le S[i]$
+    # single-centroid: linear ramp between t_min and t_max (0.5 for a degenerate range)
+    rng = t_max - t_min
+    res_single = torch.where(xv < t_min, torch.zeros_like(xv),
+                 torch.where(xv > t_max, torch.ones_like(xv),
+                 torch.where(rng < eps, torch.full_like(xv, 0.5),
+                             (xv - t_min) / torch.where(rng == 0, 1.0, rng))))
 
-    # initialize results for active elements
-    res = torch.zeros_like(x_active)
-
-    # --- min < x < first centroid ---
-    m1 = x_active < cent_mean[0]
-    if m1.any():
-        x0, x1 = t_min, cent_mean[0]
-        dw = cent_merged_weight[0] / 2.0
-        res[m1] = dw * (x_active[m1] - x0) / (x1 - x0) / total_weight
-
-    # --- last centroid < x < max ---
-    m2 = (~m1) & (i_l == num_centroids)
-    if m2.any():
-        idx_last = num_centroids - 1
-        x0, x1 = cent_mean[idx_last], t_max
-        dw = cent_weight[idx_last] / 2.0
-        res[m2] = 1.0 - dw * (x1 - x_active[m2]) / (x1 - x0) / total_weight
-
-    # --- x is equal to one or more centroids ---
-    m3 = (~m1) & (~m2) & (cent_mean[i_l.clamp(max=num_centroids - 1)] == x_active)
-    if m3.any():
-        # side='right' finds the upper bound of the equality range
-        i_r = torch.searchsorted(cent_mean, x_active, side="right")
-        res[m3] = cent_merged_weight[i_r[m3]] / total_weight
-
-    # --- x between two centroids ---
-    m4 = (~m1) & (~m2) & (~m3)
-    if m4.any():
-        idx_l = i_l[m4]
-        x0 = cent_mean[idx_l - 1]
-        x1 = cent_mean[idx_l]
-        dw = 0.5 * (cent_weight[idx_l - 1] + cent_weight[idx_l])
-        interpolated = cent_merged_weight[idx_l - 1] + dw * (x_active[m4] - x0) / (x1 - x0)
-        res[m4] = interpolated / total_weight
-
-    out[active_mask] = res
+    out = torch.where(n_real <= 1, res_single, res_multi)
+    # empty digest -> nan, matching the original behavior
+    out = torch.where(n_real == 0, torch.full_like(out, float("nan")), out)
     return out
 
 
-def tdigest_quantile_tensor(qv, cent_mean, cent_weight, t_min, t_max):
-    num_centroids = cent_mean.numel()
+def tdigest_quantile_tensor(qv, cent_mean, cent_weight, t_min, t_max, n_real):
+    """Evaluate the TDigest inverse CDF (quantile function) at every element of ``qv`` for a single variable.
 
+    Branchless, fixed-shape reformulation of the original masked implementation for ``torch.vmap``
+    compatibility. See ``tdigest_cdf_tensor`` for the padding/``n_real`` convention.
+
+    Args:
+        qv (torch.Tensor): quantiles in ``[0, 1]``, any shape.
+        cent_mean (torch.Tensor): padded ``(K,)`` centroid means, ascending, padding = ``+inf``.
+        cent_weight (torch.Tensor): padded ``(K,)`` centroid weights, padding = ``0``.
+        t_min, t_max: scalar min/max of the digest.
+        n_real: number of valid centroids.
+
+    Returns:
+        torch.Tensor: interpolated values with the same shape as ``qv``.
+    """
+    K = cent_mean.numel()
     cum_sum = torch.cumsum(cent_weight, dim=0)
     cent_merged_weight = cum_sum - (cent_weight / 2.0)
     total_weight = cent_weight.sum()
+    nlast = torch.clamp(n_real - 1, min=0)
 
-    out = torch.full(qv.shape, torch.nan, dtype=qv.dtype, device=qv.device)
-
-    if total_weight == 0:
-        return out
-
-    out = torch.where(qv <= 0, t_min, out)
-    out = torch.where(qv >= 1, t_max, out)
-
-    if num_centroids == 1:
-        mask = (qv > 0) & (qv < 1)
-        out[mask] = cent_mean[0]  # valid ones return the "mean"
-        return out
-
-    # identify indices that still need processing
-    active_mask = torch.isnan(out)
-    if not active_mask.any():
-        return out
-
-    q_active = qv[active_mask]
-    target_weight = q_active * total_weight
-
-    idx_r = torch.searchsorted(cent_merged_weight, target_weight, side="left")
+    target_weight = qv * total_weight
+    # padding merged-weights equal total_weight, so idx_r lands at n_real once past the last real centroid
+    idx_r = _bucketize(cent_merged_weight, target_weight, "left")  # in [0, K]
     idx_l = idx_r - 1
+    at_end = idx_r >= n_real
+    idx_r_c = torch.minimum(idx_r, nlast)
+    idx_l_c = torch.clamp(idx_l, min=0)
 
-    # --- define x0, y0 (Left boundary of interpolation) ---
-    # If idx_r is 0, we interpolate from (0, t_min)
-    x0 = torch.where(idx_r == 0, 0.0, cent_merged_weight[idx_l.clamp(min=0)])
-    y0 = torch.where(idx_r == 0, t_min, cent_mean[idx_l.clamp(min=0)])
+    # left boundary: (0, t_min) when idx_r == 0, else the merged-weight/mean of the left centroid
+    x0 = torch.where(idx_r == 0, torch.zeros_like(target_weight), cent_merged_weight[idx_l_c])
+    y0 = torch.where(idx_r == 0, t_min + torch.zeros_like(target_weight), cent_mean[idx_l_c])
+    # right boundary: (total_weight, t_max) past the last centroid, else the merged-weight/mean of the right centroid
+    x1 = torch.where(at_end, total_weight + torch.zeros_like(target_weight), cent_merged_weight[idx_r_c])
+    y1 = torch.where(at_end, t_max + torch.zeros_like(target_weight), cent_mean[idx_r_c])
 
-    # --- define x1, y1 (right boundary of interpolation) ---
-    at_end = (idx_r == num_centroids)
-    x1 = torch.where(at_end, total_weight, cent_merged_weight[idx_r.clamp(max=num_centroids-1)])
-    y1 = torch.where(at_end, t_max, cent_mean[idx_r.clamp(max=num_centroids-1)])
-
-    # --- linear interpolation formula: y = y0 + (x - x0) * (y1 - y0) / (x1 - x0) ---
     denom = x1 - x0
     res = y0 + (target_weight - x0) * (y1 - y0) / torch.where(denom == 0, 1e-9, denom)
 
-    out[active_mask] = res
+    # single centroid: interior quantiles all map to the single mean
+    res = torch.where(n_real <= 1, cent_mean[0] + torch.zeros_like(qv), res)
+
+    out = torch.where(qv <= 0, t_min + torch.zeros_like(qv),
+          torch.where(qv >= 1, t_max + torch.zeros_like(qv), res))
+    # empty digest -> nan, matching the original behavior
+    out = torch.where(n_real == 0, torch.full_like(out, float("nan")), out)
     return out
 
 
@@ -620,12 +658,18 @@ class DQuantileScalerTensor(DBaseScalerTensor):
         min_val: Minimum value for quantile to prevent -inf results when distribution is normal or logistic.
         max_val: Maximum value for quantile to prevent inf results when distribution is normal or logistic.
         channels_last: Whether to assume the last dim or second dim are the channel/variable dimension.
+        compile: If True, transform/inverse_transform run through a cached ``torch.compile(fullgraph=True)`` of the
+            vmapped per-variable kernel, which fuses the many elementwise ops for a sizable speedup on CPU/CUDA.
+            Compilation is skipped on MPS (its inductor backend is immature and the ``_bucketize`` fallback already
+            handles MPS); the default False preserves the plain eager-vmap behavior.
     """
-    def __init__(self, compression=250, distribution="uniform", min_val=0.0000001, max_val=0.9999999, channels_last=True):
+    def __init__(self, compression=250, distribution="uniform", min_val=0.0000001, max_val=0.9999999,
+                 channels_last=True, compile=False):
         self.compression = compression
         self.distribution = distribution
         self.min_val = min_val
         self.max_val = max_val
+        self.compile = compile
         self.centroids_ = None
         self.size_ = None
         self.min_ = None
@@ -634,6 +678,10 @@ class DQuantileScalerTensor(DBaseScalerTensor):
         self.centroids_weight_tensor = None
         self.min_tensor = None
         self.max_tensor = None
+        # Padded/stacked centroid tensors used by the vmap-parallelized transforms.
+        self.centroids_mean_stacked = None    # (n_vars, max_centroids), padding means = +inf
+        self.centroids_weight_stacked = None  # (n_vars, max_centroids), padding weights = 0
+        self.centroids_count = None           # (n_vars,) number of real centroids per variable
 
         super().__init__(channels_last=channels_last)
 
@@ -662,6 +710,39 @@ class DQuantileScalerTensor(DBaseScalerTensor):
         self.centroids_weight_tensor = [torch.from_numpy(c[:, 1]) for c in self.centroids_]  # "weight"
         self.min_tensor = torch.from_numpy(self.min_)
         self.max_tensor = torch.from_numpy(self.max_)
+        self.build_stacked_centroids()
+        return
+
+    def build_stacked_centroids(self):
+        """Pad the ragged per-variable centroid lists into rectangular tensors for ``torch.vmap``.
+
+        Each variable's TDigest has a different number of centroids, so the per-variable ``(k_i,)`` mean/weight
+        tensors cannot be batched directly. This pads every variable to ``K = max(k_i)`` columns, filling padding
+        means with ``+inf`` (so they sort past all real centroids and are never selected by ``searchsorted``) and
+        padding weights with ``0`` (so they contribute nothing to the cumulative/total weights). ``centroids_count``
+        records the real centroid count per variable so the transform kernels know where the padding begins.
+        """
+        means = self.centroids_mean_tensor
+        weights = self.centroids_weight_tensor
+        counts = [m.shape[0] for m in means]
+        n_vars = len(means)
+        max_k = max(counts) if counts else 0
+        dtype = means[0].dtype if n_vars else torch.float64
+        mean_stacked = torch.full((n_vars, max_k), float("inf"), dtype=dtype)
+        weight_stacked = torch.zeros((n_vars, max_k), dtype=dtype)
+        for i, (m, w) in enumerate(zip(means, weights)):
+            k = m.shape[0]
+            mean_stacked[i, :k] = m
+            weight_stacked[i, :k] = w
+        self.centroids_mean_stacked = mean_stacked
+        self.centroids_weight_stacked = weight_stacked
+        self.centroids_count = torch.tensor(counts, dtype=torch.long)
+        return
+
+    def ensure_stacked_centroids(self):
+        """Rebuild the stacked centroid tensors if missing (e.g. loaded from an older serialized scaler)."""
+        if self.centroids_mean_stacked is None and self.centroids_mean_tensor is not None:
+            self.build_stacked_centroids()
         return
 
     def fit(self, x, weight=None):
@@ -696,25 +777,57 @@ class DQuantileScalerTensor(DBaseScalerTensor):
         self._fit = True
         return
 
+    def _gather_scales(self, x_col_order, xv):
+        """Select and stack the padded centroid parameters for the requested variables onto ``xv``'s device.
+
+        Returns per-variable tensors aligned with the channel order of ``xv`` (indexed by ``x_col_order``):
+        stacked means ``(n_sel, K)``, stacked weights ``(n_sel, K)``, min ``(n_sel,)``, max ``(n_sel,)``, and
+        real-centroid counts ``(n_sel,)`` — ready to be mapped over dim 0 by ``torch.vmap``.
+        """
+        self.ensure_stacked_centroids()
+        order = torch.as_tensor(x_col_order, dtype=torch.long)
+        mean = self.centroids_mean_stacked.index_select(0, order).to(xv.device, dtype=xv.dtype)
+        weight = self.centroids_weight_stacked.index_select(0, order).to(xv.device, dtype=xv.dtype)
+        t_min = self.min_tensor.index_select(0, order).to(xv.device, dtype=xv.dtype)
+        t_max = self.max_tensor.index_select(0, order).to(xv.device, dtype=xv.dtype)
+        n_real = self.centroids_count.index_select(0, order).to(xv.device)
+        return mean, weight, t_min, t_max, n_real
+
+    def _get_batched_fn(self, kind, channel_dim, device_type):
+        """Build (and cache) the vmapped per-variable transform, optionally wrapped in ``torch.compile``.
+
+        The per-variable kernel is mapped over the channel dimension (stacked params on dim 0, xv on
+        ``channel_dim``). When ``self.compile`` is set and the data is not on MPS, the vmapped function is wrapped
+        in ``torch.compile(fullgraph=True)`` so inductor fuses the many elementwise ops into a few kernels. The
+        cache is keyed by ``(kind, channel_dim, use_compile)`` so channels-first/last and compiled/eager variants
+        coexist, and lives in a module-level weak map so nothing non-serializable lands on the scaler.
+        """
+        use_compile = bool(self.compile) and device_type != "mps"
+        key = (kind, channel_dim, use_compile)
+        cache = _BATCHED_CACHE.get(self)
+        if cache is None:
+            cache = {}
+            _BATCHED_CACHE[self] = cache
+        batched = cache.get(key)
+        if batched is None:
+            if kind == "transform":
+                base = partial(transform_variable_tensor, min_val=self.min_val, max_val=self.max_val,
+                               distribution=self.distribution)
+            else:
+                base = partial(inv_transform_variable_tensor, distribution=self.distribution)
+            batched = torch.vmap(base, in_dims=(0, 0, 0, 0, 0, channel_dim), out_dims=channel_dim)
+            if use_compile:
+                batched = torch.compile(batched, fullgraph=True)
+            cache[key] = batched
+        return batched
+
     def transform(self, x, channels_last=None):
         xv, x_transformed, channels_last, channel_dim, x_col_order = self.process_x_for_transform(x, channels_last)
-
-        trans_var_func = partial(transform_variable_tensor,
-                                 min_val=self.min_val, max_val=self.max_val,
-                                 distribution=self.distribution)
-
-        if channels_last:
-            for i, o in enumerate(x_col_order):
-                x_transformed[..., i] = trans_var_func(self.centroids_mean_tensor[o].to(xv.device, dtype=xv.dtype),
-                                                       self.centroids_weight_tensor[o].to(xv.device, dtype=xv.dtype),
-                                                       self.min_tensor[o].to(xv.device, dtype=xv.dtype),
-                                                       self.max_tensor[o].to(xv.device, dtype=xv.dtype), xv[..., i])
-        else:
-            for i, o in enumerate(x_col_order):
-                x_transformed[:, i] = trans_var_func(self.centroids_mean_tensor[o].to(xv.device, dtype=xv.dtype),
-                                                     self.centroids_weight_tensor[o].to(xv.device, dtype=xv.dtype),
-                                                     self.min_tensor[o].to(xv.device, dtype=xv.dtype),
-                                                     self.max_tensor[o].to(xv.device, dtype=xv.dtype), xv[:, i])
+        mean, weight, t_min, t_max, n_real = self._gather_scales(x_col_order, xv)
+        # vmap parallelizes the per-variable transform over the channel dimension, which is far faster than a
+        # Python loop; when compile is enabled the fused torch.compile variant is used (see _get_batched_fn).
+        batched = self._get_batched_fn("transform", channel_dim, xv.device.type)
+        x_transformed = batched(mean, weight, t_min, t_max, n_real, xv)
 
         x_transformed_final = self.package_transformed_x(x_transformed, x)
         return x_transformed_final
@@ -725,19 +838,10 @@ class DQuantileScalerTensor(DBaseScalerTensor):
 
     def inverse_transform(self, x, channels_last=None):
         xv, x_transformed, channels_last, channel_dim, x_col_order = self.process_x_for_transform(x, channels_last)
+        mean, weight, t_min, t_max, n_real = self._gather_scales(x_col_order, xv)
 
-        inv_trans_var_func = partial(inv_transform_variable_tensor,
-                                     distribution=self.distribution)
-        if channels_last:
-            for i, o in enumerate(x_col_order):
-                x_transformed[..., i] = inv_trans_var_func(self.centroids_mean_tensor[o].to(xv.device, dtype=xv.dtype),
-                                                           self.centroids_weight_tensor[o].to(xv.device, dtype=xv.dtype),
-                                                           self.min_tensor[o], self.max_tensor[o], xv[..., i])
-        else:
-            for i, o in enumerate(x_col_order):
-                x_transformed[:, i] = inv_trans_var_func(self.centroids_mean_tensor[o].to(xv.device, dtype=xv.dtype),
-                                                         self.centroids_weight_tensor[o].to(xv.device, dtype=xv.dtype),
-                                                         self.min_tensor[o], self.max_tensor[o], xv[:, i])
+        batched = self._get_batched_fn("inverse", channel_dim, xv.device.type)
+        x_transformed = batched(mean, weight, t_min, t_max, n_real, xv)
 
         x_transformed_final = self.package_transformed_x(x_transformed, x)
         return x_transformed_final

--- a/bridgescaler/distributed_tensor.py
+++ b/bridgescaler/distributed_tensor.py
@@ -546,8 +546,10 @@ def tdigest_cdf_tensor(xv, cent_mean, cent_weight, t_min, t_max, n_real):
     i_r_c = torch.minimum(i_r, nlast)
 
     first_mean = cent_mean[0]
-    last_mean = cent_mean[nlast]
-    last_w = cent_weight[nlast]
+    # index with a 1-d index via index_select rather than cent_mean[nlast]: indexing by a 0-d tensor
+    # calls .item() internally, which torch.vmap forbids on older torch versions.
+    last_mean = cent_mean.index_select(0, nlast.reshape(1)).squeeze(0)
+    last_w = cent_weight.index_select(0, nlast.reshape(1)).squeeze(0)
 
     # --- case m1: t_min < x < first centroid ---
     dw1 = cent_merged_weight[0] / 2.0

--- a/bridgescaler/tests/distributed_tensor_test.py
+++ b/bridgescaler/tests/distributed_tensor_test.py
@@ -5,6 +5,26 @@ import numpy as np
 import pytest
 import torch
 import os
+import functools
+
+
+@functools.lru_cache(maxsize=1)
+def _inductor_cpu_available():
+    """Probe whether torch.compile's Inductor CPU backend can actually build a kernel.
+
+    On some HPC module environments the ``g++`` on PATH is a wrapper (e.g. NCAR's
+    ``ncarcompilers``) that injects link flags, which breaks Inductor's header-only
+    precompile step and raises a CppCompileError. That is a toolchain issue, not a
+    bridgescaler bug, so tests that require compilation skip rather than fail.
+    Set ``CXX`` to a plain g++ to make this probe (and the compile path) succeed.
+    """
+    try:
+        fn = torch.compile(lambda t: t * 2 + 1, fullgraph=True)
+        fn(torch.randn(4))
+    except Exception:
+        return False
+    return True
+
 
 def make_test_data():
     np.random.seed(34325)
@@ -296,9 +316,72 @@ def test_tensor_scaler_with_attribute():
         #assert scaler.transform(x_attr).is_cuda == False, "device should be CPU"
 
 
+def test_dquantile_tensor_fast_transform():
+    # fast_transform replaces the exact TDigest CDF/quantile eval with a per-variable monotone-cubic (PCHIP)
+    # approximation in BOTH directions. Knots are lazy (built on first transform, invalidated on refit) and must
+    # survive save/load, compose with channels_first + column subsetting, and match the exact path in the bulk.
+    rng = np.random.default_rng(0)
+    for dist in ["uniform", "normal", "logistic"]:
+        data = np.stack([rng.lognormal(0, 1, 6000), rng.normal(3, 2, 6000),
+                         rng.uniform(-1, 1, 6000), rng.exponential(2.0, 6000)], axis=1)
+        x = torch.from_numpy(data.copy())
+        exact = DQuantileScalerTensor(distribution=dist)
+        fast = DQuantileScalerTensor(distribution=dist, fast_transform=True, n_knots=256)
+        exact.fit(x)
+        fast.fit(x)
+        assert fast.knots_x_ is None, "knots should be lazy (unbuilt) right after fit"
+        ze = exact.transform(x)
+        zf = fast.transform(x)
+        assert fast.knots_x_ is not None, "knots should be built on first transform"
+        assert torch.all(~torch.isnan(zf)) and zf.shape == x.shape, f"bad fast transform for {dist}"
+        # bulk (99th percentile) error vs the exact path is small; the extreme tail worst-case is larger by design
+        assert torch.quantile(torch.abs(zf - ze), 0.99) < 0.05, f"fast_transform bulk error too high for {dist}"
+        # fast inverse vs exact inverse (both applied to the exact-transform output), in data space
+        xe = exact.inverse_transform(ze)
+        xf = fast.inverse_transform(ze)
+        assert torch.all(~torch.isnan(xf)) and xf.shape == x.shape, f"bad fast inverse for {dist}"
+        tol = 0.05 * (xe.max() - xe.min())
+        assert torch.quantile(torch.abs(xf - xe), 0.99) < tol, f"fast inverse bulk error too high for {dist}"
+
+    # refit invalidates the cached knots so a stale curve is never reused
+    fast.fit(x)
+    assert fast.knots_x_ is None, "refit must invalidate fast_transform knots"
+
+    # channels_first + column subsetting/reordering compose with the fast path
+    x4 = torch.randn(400, 4, 4, 4, dtype=torch.float64)
+    for c in range(4):
+        x4[:, c] = x4[:, c] * (c + 1) + c
+    x4.variable_names = ["a", "b", "c", "d"]
+    fast_cf = DQuantileScalerTensor(distribution="normal", channels_last=False, fast_transform=True)
+    full = fast_cf.fit_transform(x4)
+    x_sel = x4[:, [0, 2, 1], :, :].clone()
+    x_sel.variable_names = ["a", "c", "b"]
+    assert torch.allclose(fast_cf.transform(x_sel), full[:, [0, 2, 1]], atol=1e-9), \
+        "fast_transform must respect column subsetting/reordering"
+
+    # save/load round-trip: lazy (knots None) and after knots are built
+    data = torch.from_numpy(rng.lognormal(0, 1, (4000, 3)))
+    s = DQuantileScalerTensor(distribution="normal", fast_transform=True)
+    s.fit(data)
+    save_scaler(s, "fast_scaler.json")
+    s2 = load_scaler("fast_scaler.json")
+    os.remove("fast_scaler.json")
+    assert s2.fast_transform is True and int(s2.n_knots) == 256, "fast_transform config lost on load"
+    assert s2.knots_x_ is None, "unbuilt knots should load back as None"
+    assert torch.allclose(s2.transform(data), s.transform(data), atol=1e-9), "fast transform changed after load"
+    save_scaler(s, "fast_scaler.json")  # now knots are built
+    s3 = load_scaler("fast_scaler.json")
+    os.remove("fast_scaler.json")
+    assert torch.is_tensor(s3.knots_x_), "built knots should round-trip as a tensor"
+    assert torch.allclose(s3.transform(data), s.transform(data), atol=1e-9), "fast transform changed after load"
+
+
 def test_dquantile_tensor_compile_matches_eager():
     # compile=True uses torch.compile(fullgraph=True) on the vmapped kernel. fullgraph=True raises on any graph
     # break, so if this runs at all there is no graph break; we also assert it matches the eager path exactly.
+    if not _inductor_cpu_available():
+        pytest.skip("torch.compile Inductor CPU backend cannot build kernels in this environment "
+                    "(likely a compiler-toolchain issue; set CXX to a plain g++)")
     torch.manual_seed(7)
     x = torch.randn(6, 8, 4, 5, dtype=torch.float64)
     for c in range(x.shape[1]):

--- a/bridgescaler/tests/distributed_tensor_test.py
+++ b/bridgescaler/tests/distributed_tensor_test.py
@@ -130,6 +130,60 @@ def test_dquantile_tensor_scaler():
         "Summing did not work properly."
 
 
+def test_dquantile_tensor_vmap_edge_cases():
+    # 5D (batch, channel, time, y, x) channels_first with per-variable scaling so centroid counts differ
+    torch.manual_seed(11)
+    x = torch.randn(4, 40, 6, 16, 16, dtype=torch.float64)
+    for c in range(x.shape[1]):
+        x[:, c] = x[:, c] * (c + 1) + c
+    for dist in ["uniform", "normal", "logistic"]:
+        sc = DQuantileScalerTensor(channels_last=False, distribution=dist)
+        t = sc.fit_transform(x)
+        it = sc.inverse_transform(t)
+        # stacked centroid tensors are built with +inf mean padding and 0 weight padding
+        assert sc.centroids_count.shape[0] == x.shape[1], "one centroid count per variable"
+        assert torch.isinf(sc.centroids_mean_stacked).any(), "ragged centroids should be inf-padded"
+        assert torch.all(~torch.isnan(t)) and torch.all(~torch.isnan(it)), f"nans for {dist}"
+        assert t.shape == x.shape and it.shape == x.shape, "shape preserved"
+
+    # single-centroid (constant / single-example) variables exercise the n_real <= 1 branch
+    x1 = torch.tensor([[2.5, -1.0]], dtype=torch.float64)
+    sc = DQuantileScalerTensor(distribution="uniform")
+    t = sc.fit_transform(x1)
+    it = sc.inverse_transform(t)
+    assert sc.centroids_count.tolist() == [1, 1], "single-example fit yields one centroid per variable"
+    assert torch.all(~torch.isnan(t)) and torch.all(~torch.isnan(it)), "nans in single-centroid path"
+    assert torch.allclose(it, x1, atol=1e-6), "single-centroid inverse should recover the value"
+
+
+def test_dquantile_tensor_refit_rebuilds_stacked_centroids():
+    # Repeated fit on different subsets must rebuild the padded/stacked centroid tensors used by vmap,
+    # otherwise transform would keep using stale centroids from the first subset only.
+    torch.manual_seed(3)
+    scale = torch.tensor([1., 5., 20., 100.], dtype=torch.float64)
+    a = torch.randn(300, 4, dtype=torch.float64) * scale
+    b = torch.randn(500, 4, dtype=torch.float64) * scale + 3.0
+    a.variable_names = b.variable_names = ["v1", "v2", "v3", "v4"]
+
+    sc = DQuantileScalerTensor(distribution="normal")
+    sc.fit(a)
+    stacked_1 = sc.centroids_mean_stacked.clone()
+    counts_1 = sc.centroids_count.clone()
+
+    sc.fit(b)  # incremental update branch
+    # the stacked tensors must reflect the merged digest, not the first subset
+    assert sc.centroids_count.numel() == 4
+    assert (not torch.equal(counts_1, sc.centroids_count)
+            or stacked_1.shape != sc.centroids_mean_stacked.shape
+            or not torch.equal(stacked_1, sc.centroids_mean_stacked)), \
+        "stacked centroids were not rebuilt after re-fitting on a new subset"
+    # the stacked tensors must stay consistent with the ragged per-variable lists
+    for o in range(4):
+        k = sc.centroids_count[o].item()
+        assert torch.allclose(sc.centroids_mean_stacked[o, :k], sc.centroids_mean_tensor[o]), \
+            "stacked means diverged from the per-variable centroid list after re-fit"
+
+
 def test_tensor_scaler_with_attribute():
     # create synthetic data (channel_dim=1)
     x_org = torch.randn(20, 5, 4, 8) * 2.2 # without attributes
@@ -240,3 +294,22 @@ def test_tensor_scaler_with_attribute():
         #assert scaler.get_scales()[0].is_cuda, "device should be GPU"
         #assert scaler.transform(x_gpu).is_cuda, "device should be GPU"
         #assert scaler.transform(x_attr).is_cuda == False, "device should be CPU"
+
+
+def test_dquantile_tensor_compile_matches_eager():
+    # compile=True uses torch.compile(fullgraph=True) on the vmapped kernel. fullgraph=True raises on any graph
+    # break, so if this runs at all there is no graph break; we also assert it matches the eager path exactly.
+    torch.manual_seed(7)
+    x = torch.randn(6, 8, 4, 5, dtype=torch.float64)
+    for c in range(x.shape[1]):
+        x[:, c] = x[:, c] * (c + 1) + c
+    x.variable_names = [f"v{i}" for i in range(x.shape[1])]
+    for dist in ["uniform", "normal", "logistic"]:
+        eager = DQuantileScalerTensor(channels_last=False, distribution=dist)
+        comp = DQuantileScalerTensor(channels_last=False, distribution=dist, compile=True)
+        te = eager.fit_transform(x)
+        tc = comp.fit_transform(x)
+        assert torch.allclose(te, tc, atol=1e-6, equal_nan=True), f"compiled transform != eager for {dist}"
+        ie = eager.inverse_transform(te)
+        ic = comp.inverse_transform(tc)
+        assert torch.allclose(ie, ic, atol=1e-6, equal_nan=True), f"compiled inverse != eager for {dist}"

--- a/scripts/benchmark_quantile.py
+++ b/scripts/benchmark_quantile.py
@@ -1,0 +1,127 @@
+"""Benchmark DQuantileScaler (numpy/crick) vs DQuantileScalerTensor (torch) transform runtimes.
+
+Compares `transform` wall-clock time across total array sizes 1e3 .. 1e6 (powers of 10) for:
+  * DQuantileScaler          - numpy/crick, CPU
+  * DQuantileScalerTensor    - torch, CPU (eager)
+  * DQuantileScalerTensor    - torch, GPU (eager)
+  * DQuantileScalerTensor    - torch, GPU (torch.compile)   [if CUDA available]
+
+Fitting is done once per configuration and is NOT timed; only `transform` is timed, over
+several repeats after warmup. GPU timings synchronize the device around each call.
+"""
+import time
+
+import numpy as np
+import torch
+
+from bridgescaler.distributed import DQuantileScaler
+from bridgescaler.distributed_tensor import DQuantileScalerTensor
+
+N_VARS = 4               # number of variables/channels
+SIZES = [1_000, 10_000, 100_000, 1_000_000]   # total array elements
+DISTRIBUTION = "normal"
+N_REPEAT = 20            # timed repeats per config
+N_WARMUP = 3
+SEED = 20240706
+
+
+def make_data(total_size, n_vars=N_VARS):
+    """Build a (rows, n_vars) float64 array with total elements ~= total_size."""
+    rows = max(total_size // n_vars, 1)
+    rng = np.random.default_rng(SEED)
+    # give each variable a different distribution so the digests differ
+    data = np.empty((rows, n_vars), dtype=np.float64)
+    for v in range(n_vars):
+        data[:, v] = rng.normal(loc=v * 3.0, scale=1.0 + v, size=rows)
+    return data
+
+
+def time_call(fn, n_repeat=N_REPEAT, n_warmup=N_WARMUP, sync=None):
+    """Return (median, min) seconds over n_repeat timed calls after n_warmup warmups."""
+    for _ in range(n_warmup):
+        fn()
+    if sync is not None:
+        sync()
+    times = []
+    for _ in range(n_repeat):
+        if sync is not None:
+            sync()
+        t0 = time.perf_counter()
+        fn()
+        if sync is not None:
+            sync()
+        times.append(time.perf_counter() - t0)
+    times = np.array(times)
+    return float(np.median(times)), float(times.min())
+
+
+def bench_numpy_cpu(data):
+    scaler = DQuantileScaler(distribution=DISTRIBUTION)
+    scaler.fit(data)
+    ref = scaler.transform(data)
+    med, mn = time_call(lambda: scaler.transform(data))
+    return med, mn, ref
+
+
+def bench_tensor(data, device, compile_flag=False, ref=None):
+    scaler = DQuantileScalerTensor(distribution=DISTRIBUTION, compile=compile_flag)
+    # fit on CPU (fit_variable_tensor pulls data to CPU/numpy internally)
+    scaler.fit(torch.from_numpy(data))
+    x = torch.from_numpy(data).to(device)
+    sync = torch.cuda.synchronize if device.type == "cuda" else None
+
+    out = scaler.transform(x)
+    max_err = None
+    if ref is not None:
+        max_err = float(np.nanmax(np.abs(out.cpu().numpy() - ref)))
+    med, mn = time_call(lambda: scaler.transform(x), sync=sync)
+    return med, mn, max_err
+
+
+def main():
+    cuda = torch.cuda.is_available()
+    print(f"torch {torch.__version__} | CUDA available: {cuda}"
+          + (f" | {torch.cuda.get_device_name(0)}" if cuda else ""))
+    print(f"n_vars={N_VARS}, distribution={DISTRIBUTION}, "
+          f"repeats={N_REPEAT} (median reported), warmup={N_WARMUP}\n")
+
+    header = f"{'size':>10} {'np-cpu (ms)':>13} {'tensor-cpu (ms)':>16} {'tensor-gpu (ms)':>16}"
+    if cuda:
+        header += f" {'tensor-gpu-compile (ms)':>24}"
+    print(header)
+    print("-" * len(header))
+
+    results = []
+    for size in SIZES:
+        data = make_data(size)
+
+        np_med, np_min, ref = bench_numpy_cpu(data)
+        tc_med, tc_min, tc_err = bench_tensor(data, torch.device("cpu"), ref=ref)
+
+        row = f"{size:>10} {np_med*1e3:>13.3f} {tc_med*1e3:>16.3f}"
+        rec = {"size": size, "np_cpu": np_med, "tensor_cpu": tc_med,
+               "tensor_cpu_maxerr": tc_err}
+
+        if cuda:
+            dev = torch.device("cuda")
+            tg_med, tg_min, tg_err = bench_tensor(data, dev, ref=ref)
+            tgc_med, tgc_min, tgc_err = bench_tensor(data, dev, compile_flag=True, ref=ref)
+            row += f" {tg_med*1e3:>16.3f} {tgc_med*1e3:>24.3f}"
+            rec.update(tensor_gpu=tg_med, tensor_gpu_compile=tgc_med,
+                       tensor_gpu_maxerr=tg_err)
+        else:
+            row += f" {'n/a':>16}"
+        print(row)
+        results.append(rec)
+
+    # correctness summary
+    print("\nMax abs error vs numpy transform (should be ~1e-6 or smaller):")
+    for rec in results:
+        msg = f"  size={rec['size']:>9}: cpu={rec['tensor_cpu_maxerr']:.2e}"
+        if "tensor_gpu_maxerr" in rec:
+            msg += f", gpu={rec['tensor_gpu_maxerr']:.2e}"
+        print(msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_standard_vs_quantile.py
+++ b/scripts/benchmark_standard_vs_quantile.py
@@ -1,0 +1,114 @@
+"""Compare DStandardScalerTensor vs DQuantileScalerTensor transform time at 1M elements.
+
+Configurations: CPU (eager), GPU (eager), GPU (torch.compile). DQuantileScalerTensor has a
+built-in `compile` flag; DStandardScalerTensor does not, so its transform is wrapped in
+torch.compile manually for the compiled case. Only `transform` is timed (fit excluded),
+median of N_REPEAT repeats after warmup, with CUDA synchronization around GPU calls.
+"""
+import time
+
+import numpy as np
+import torch
+
+from bridgescaler.distributed_tensor import DStandardScalerTensor, DQuantileScalerTensor
+
+N_VARS = 4
+TOTAL_SIZE = 1_000_000
+DISTRIBUTION = "normal"
+N_REPEAT = 20
+N_WARMUP = 5
+SEED = 20240706
+
+
+def make_data():
+    rows = TOTAL_SIZE // N_VARS
+    rng = np.random.default_rng(SEED)
+    data = np.empty((rows, N_VARS), dtype=np.float64)
+    for v in range(N_VARS):
+        data[:, v] = rng.normal(v * 3.0, 1.0 + v, rows)
+    return data
+
+
+def time_call(fn, sync=None):
+    for _ in range(N_WARMUP):
+        fn()
+    if sync is not None:
+        sync()
+    times = []
+    for _ in range(N_REPEAT):
+        if sync is not None:
+            sync()
+        t0 = time.perf_counter()
+        fn()
+        if sync is not None:
+            sync()
+        times.append(time.perf_counter() - t0)
+    return float(np.median(times))
+
+
+def main():
+    cuda = torch.cuda.is_available()
+    print(f"torch {torch.__version__} | CUDA: {cuda}"
+          + (f" | {torch.cuda.get_device_name(0)}" if cuda else ""))
+    print(f"size={TOTAL_SIZE}, n_vars={N_VARS}, distribution={DISTRIBUTION}, "
+          f"repeats={N_REPEAT} (median ms)\n")
+
+    data = make_data()
+
+    def std_scaler():
+        s = DStandardScalerTensor()
+        s.fit(torch.from_numpy(data))
+        return s
+
+    def quant_scaler(compile_flag=False):
+        s = DQuantileScalerTensor(distribution=DISTRIBUTION, compile=compile_flag)
+        s.fit(torch.from_numpy(data))
+        return s
+
+    configs = []  # (label, seconds)
+
+    # ---- CPU eager ----
+    dev = torch.device("cpu")
+    x = torch.from_numpy(data).to(dev)
+    s = std_scaler()
+    configs.append(("DStandardScalerTensor  CPU (eager)", time_call(lambda: s.transform(x))))
+    q = quant_scaler()
+    configs.append(("DQuantileScalerTensor  CPU (eager)", time_call(lambda: q.transform(x))))
+
+    if cuda:
+        dev = torch.device("cuda")
+        x = torch.from_numpy(data).to(dev)
+        sync = torch.cuda.synchronize
+
+        # ---- GPU eager ----
+        s = std_scaler()
+        configs.append(("DStandardScalerTensor  GPU (eager)", time_call(lambda: s.transform(x), sync=sync)))
+        q = quant_scaler()
+        configs.append(("DQuantileScalerTensor  GPU (eager)", time_call(lambda: q.transform(x), sync=sync)))
+
+        # ---- GPU compiled ----
+        # DStandardScalerTensor has no built-in compile flag, and torch.compile(s.transform) drags the
+        # CPU-resident stat tensors + device-moves into the graph (forcing a CPU C++ compile). So we
+        # pre-move the fitted stats to GPU and compile the pure elementwise standardization, keeping the
+        # graph all-CUDA (Triton) -- the fair analogue of DQuantileScalerTensor's built-in GPU compile.
+        s = std_scaler()
+        g_mean = s.mean_x_.to(dev)
+        g_var = s.var_x_.to(dev)
+
+        def std_math(xt):
+            return (xt - g_mean) / torch.sqrt(g_var)  # channels_last broadcast over last dim
+
+        s_compiled = torch.compile(std_math, fullgraph=True)
+        configs.append(("DStandardScalerTensor  GPU (compile)", time_call(lambda: s_compiled(x), sync=sync)))
+        q = quant_scaler(compile_flag=True)
+        configs.append(("DQuantileScalerTensor  GPU (compile)", time_call(lambda: q.transform(x), sync=sync)))
+
+    width = max(len(lbl) for lbl, _ in configs)
+    print(f"{'config'.ljust(width)}   median (ms)")
+    print("-" * (width + 15))
+    for lbl, sec in configs:
+        print(f"{lbl.ljust(width)}   {sec*1e3:>9.3f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Speed up `DQuantileScalerTensor`: vmap parallelization + `fast_transform` approximation

### Summary

This PR overhauls `DQuantileScalerTensor` for performance while keeping serialized attributes in sync with the original `DQuantileScaler`. The first refactor restructured the internal tensors to keep shapes the same to make vmap behave nicely. The second change is an optional further speedup that approximates the quantile CDF curve with a PCHIP spline. Torch compile on top of both of these optimizations provides even further opitmization so that quantile transform is now faster on GPU with compilation than standard scaler on CPU and only about 5x slower than standard scaler compiled on GPU. 

### Changes

#### 1. Vectorize per-variable transforms with `torch.vmap` (`5f20051`)

- Rewrote the TDigest CDF/quantile kernels (`tdigest_cdf_tensor`, `tdigest_quantile_tensor`) to be branchless and fixed-shape (all interpolation cases computed, selected via `torch.where`) so they compose with `vmap`.
- Centroids are padded into rectangular `(n_vars, K)` tensors with a per-variable real-centroid count; `transform`/`inverse_transform` now map the kernel over the channel dim instead of a Python loop. **~3× faster than the loop, ~1.5–1.7× faster than numpy `DQuantileScaler` at scale.** Stacked tensors are rebuilt on every fit, including the incremental-update path.
- **Optional `compile=True`**: runs the vmapped kernel through a cached `torch.compile(fullgraph=True)` (~2.3× on CPU, more expected on CUDA). Cache lives in a module-level weak map, so nothing non-serializable is stored on the scaler.
- **MPS-friendly `searchsorted`**: routes through `_bucketize`, which falls back to a broadcast reduction on MPS (whose `searchsorted` kernel is ~60× slower than CPU) while keeping binary-search on CPU/CUDA. **~13× faster MPS transforms.** The device check is a static branch (no graph break).
- **Serialization fix**: `read_scaler` was converting scalar params via `torch.tensor(v)`, silently downcasting floats to float32 and corrupting precision-sensitive values (e.g. `max_val` 0.9999999 → 0.99999988), which drifted normal/logistic transforms after load. Pure-python scalars/flags are now kept as-is; reload is bit-exact.

#### 2. `fast_transform` PCHIP approximation (`3f3c0ae`)

- Opt-in mode that approximates the fitted quantile curve with a per-variable monotone-cubic (PCHIP) interpolation in both `transform` and `inverse_transform`: **~3× speedup** at a small, tail-concentrated accuracy cost (typically below the TDigest's own error).
- Knots are lazy, derived state, rebuilt on fit/merge; `read_scaler` round-trips unbuilt (`None`) knots.
- README documents the tensor scalers and their `compile`/`fast_transform` options.

#### 3. Benchmark scripts (`b256c0c`)

- `scripts/benchmark_quantile.py`, `scripts/benchmark_standard_vs_quantile.py`.

### Tests

New coverage for vmap edge cases (ragged padding, single-centroid branch), refit rebuilding stacked centroids, `fast_transform` round-trip, and compiled == eager equivalence. The `torch.compile` test skips gracefully when the Inductor CPU backend can't build kernels (e.g. a compiler-wrapper toolchain).


### Thanks
@lj-dunphy for testing quantile transforms more thoroughly.